### PR TITLE
Add quoted support for message partial subtype

### DIFF
--- a/src/mimetype_parser_lexer.xrl
+++ b/src/mimetype_parser_lexer.xrl
@@ -2,6 +2,7 @@ Definitions.
 
 WS = (\s|\t|\r|\n)
 Char = [^\(\)\<\>\@\,\;\:\\\"\/\[\]\?\=\+{WS}]+
+QuotedChar = [^\\\"{WS}]+
 
 Rules.
 
@@ -17,9 +18,14 @@ Rules.
 
 {Char}                               :  {token, {token, TokenLine, to_lower(TokenChars)}}.
 
+"{QuotedChar}+"                      :  {token, {token, TokenLine, remove_quote(TokenChars)}}.
+
 {WS}                                 :  skip_token.
 
 Erlang code.
 
 to_lower(Str) ->
   list_to_binary(string:to_lower(Str)).
+
+remove_quote(Str) ->
+  list_to_binary(string:strip(Str, both, $")).

--- a/test/mimetype_parser_test.exs
+++ b/test/mimetype_parser_test.exs
@@ -10,7 +10,8 @@ defmodule MimetypeParserTest do
     {"application/xml", [{"application", "xml", %{}}]},
     {"text/xml", [{"text", "xml", %{}}]},
     {"rdf; param=123", [{"application", "rdf+xml", %{"param" => "123"}}]},
-    {"application/hyper+json; profile=users; version=1.0", [{"application", "hyper+json", %{"profile" => "users", "version" => "1.0"}}]}
+    {"application/hyper+json; profile=users; version=1.0", [{"application", "hyper+json", %{"profile" => "users", "version" => "1.0"}}]},
+    {"application/json; profile=\"http://example.org/users\"", [{"application", "json", %{"profile" => "http://example.org/users"}}]}
   ]
 
   for {input, output} <- cases do


### PR DESCRIPTION
when a subtype has quotes to detiermine the value of its mime-type it produces an error. This should not be the way it worked according with https://www.w3.org/Protocols/rfc1341/7_3_Message.html .

Eg.
My api provider is responding to me.
`application/json; profile="http://example.org/user"`

It should be parsed correctly according with the rfc,.

Thanks if you accept this PR. ;)
